### PR TITLE
TIP-1185: Use parameters instead of strings for queries

### DIFF
--- a/api/queries/types.ts
+++ b/api/queries/types.ts
@@ -1,5 +1,14 @@
 export interface RecipeUserPreference {
-    liked?: boolean;
-    excluded?: boolean;
-    saved?: boolean;
+  liked?: boolean;
+  excluded?: boolean;
+  saved?: boolean;
+}
+
+export interface SearchQuery {
+  keywords?: string;
+  offset?: number;
+  source?: string;
+  sort?: string;
+  order?: string;
+  liked?: number;
 }


### PR DESCRIPTION
Fix #40 